### PR TITLE
Configuration option to use different separator in branchname 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# prevent accidental commit of compiled tflow binary
+/tflow

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -40,7 +40,7 @@ func doJiraIssueId(issueId string) {
 
 	branchName := issueId
 	if normalizedSummary != "" {
-		branchName += "/" + normalizedSummary
+		branchName += viper.GetString("git.branch_separator") + normalizedSummary
 	}
 
 	services.GitService{}.SwitchBranchCreateIfNotExists(branchName)

--- a/services/ConfigService.go
+++ b/services/ConfigService.go
@@ -43,6 +43,10 @@ func (c ConfigService) InitConfig() {
 			viper.Set("jira.url", answers.URL)
 			viper.Set("jira.username", answers.Username)
 			viper.Set("jira.key", answers.Key)
+			// set a default value if nothing is entered by the user
+			if answers.BranchSeparator == "" {
+				answers.BranchSeparator = "--"
+			}
 			viper.Set("git.branch_separator", answers.BranchSeparator)
 			viper.Set("jira.token", answers.Token)
 
@@ -86,8 +90,7 @@ func (c ConfigService) getConfigInteractive() configAnswers {
 		},
 		{
 			Name:     "branchSeparator",
-			Prompt:   &survey.Input{Message: "How do you want to separate the Jira key from the Jira issue title in your branch name? Most people use a slash ('/') here."},
-			Validate: survey.Required,
+			Prompt:   &survey.Input{Message: "How do you want to separate the Jira key from the Jira issue title in your branch name? (press 'enter' for default: --)"},
 		},
 		{
 			Name:     "token",

--- a/services/ConfigService.go
+++ b/services/ConfigService.go
@@ -16,10 +16,11 @@ type ConfigService struct {
 }
 
 type configAnswers struct {
-	URL      string
-	Username string
-	Key      string
-	Token    string
+	URL             string
+	Username        string
+	Key             string
+	BranchSeparator string
+	Token           string
 }
 
 func (c ConfigService) InitConfig() {
@@ -42,6 +43,7 @@ func (c ConfigService) InitConfig() {
 			viper.Set("jira.url", answers.URL)
 			viper.Set("jira.username", answers.Username)
 			viper.Set("jira.key", answers.Key)
+			viper.Set("git.branch_separator", answers.BranchSeparator)
 			viper.Set("jira.token", answers.Token)
 
 			configDirPath := homeDir + "/" + Directory + "/"
@@ -80,6 +82,11 @@ func (c ConfigService) getConfigInteractive() configAnswers {
 		{
 			Name:     "key",
 			Prompt:   &survey.Input{Message: "What key is your project using (e.g TFLOW)?"},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "branchSeparator",
+			Prompt:   &survey.Input{Message: "How do you want to separate the Jira key from the Jira issue title in your branch name? Most people use a slash ('/') here."},
 			Validate: survey.Required,
 		},
 		{


### PR DESCRIPTION
Implements #10

This will require you to manually update your config to look something like this (if you already have an existing config):
```yaml
jira:
  key: WOW
  token: 123hunter2s4p3rs3cr4t
  url: https://wowsuchproject.atlassian.net/
  username: sales@wowsuchproject.tld
git: # new section
  branch_separator: / # set to whatever you prefer
```
